### PR TITLE
Improve userparameter_lvm

### DIFF
--- a/templates/userparameter_lvm.conf
+++ b/templates/userparameter_lvm.conf
@@ -1,3 +1,3 @@
 UserParameter=lvm_thin_pool.discovery,LVM_SUPPRESS_FD_WARNINGS=1 lvs --no-heading -o lv_attr,lv_dm_path|awk 'BEGIN{ORS="";print "{\"data\":["}$1~/^t/{l=split($2,b,"/");printf "%s{\"{#TPNAME}\":\"%s\"}",sep,b[l];sep=","};END{print "]}"}'
 UserParameter=lvm_thin_volume.discovery,LVM_SUPPRESS_FD_WARNINGS=1 lvs --no-heading -o lv_attr,lv_dm_path|awk 'BEGIN{ORS="";print "{\"data\":["}$1~/^V/{l=split($2,b,"/");printf "%s{\"{#LVNAME}\":\"%s\"}",sep,b[l];sep=","};END{print "]}"}'
-UserParameter=lvm.data[*],LVM_SUPPRESS_FD_WARNINGS=1 lvs --no-heading -o lv_dm_path,$2|awk '$1~/$$1/{print $$2}'
+UserParameter=lvm.data[*],LVM_SUPPRESS_FD_WARNINGS=1 lvs --no-heading -o lv_dm_path,$2|awk '$$1~/$1/{print $$2}'

--- a/templates/userparameter_lvm.conf
+++ b/templates/userparameter_lvm.conf
@@ -1,3 +1,3 @@
-UserParameter=lvm_thin_pool.discovery,LVM_SUPPRESS_FD_WARNINGS=1 lvs --no-heading -o lv_attr,lv_dm_path|sed 's/\/dev\/mapper\///'|cut -b 3-|grep -P "^t"|awk 'BEGIN { ORS = ""; print "{\n   \"data\":[\n\n"}; { printf "   %s{\"{#TPNAME}\":\"%s\"}",sep, $2; sep=", \n"}; END { print "\n\n   ]\n}" }'
-UserParameter=lvm_thin_volume.discovery,LVM_SUPPRESS_FD_WARNINGS=1 lvs --no-heading -o lv_attr,lv_dm_path|sed 's/\/dev\/mapper\///'|cut -b 3-|grep -P "^V"|awk 'BEGIN { ORS = ""; print "{\n   \"data\":[\n\n"}; { printf "   %s{\"{#LVNAME}\":\"%s\"}",sep, $2; sep=", \n"}; END { print "\n\n   ]\n}" }'
-UserParameter=lvm.data[*],LVM_SUPPRESS_FD_WARNINGS=1 lvs --no-heading -o lv_dm_path,$2|sed 's/\/dev\/mapper\///'|awk '$$1 == "$1" { print $$2 }'
+UserParameter=lvm_thin_pool.discovery,LVM_SUPPRESS_FD_WARNINGS=1 lvs --no-heading -o lv_attr,lv_dm_path|awk 'BEGIN{ORS="";print "{\"data\":["}$1~/^t/{l=split($2,b,"/");printf "%s{\"{#TPNAME}\":\"%s\"}",sep,b[l];sep=","};END{print "]}"}'
+UserParameter=lvm_thin_volume.discovery,LVM_SUPPRESS_FD_WARNINGS=1 lvs --no-heading -o lv_attr,lv_dm_path|awk 'BEGIN{ORS="";print "{\"data\":["}$1~/^V/{l=split($2,b,"/");printf "%s{\"{#LVNAME}\":\"%s\"}",sep,b[l];sep=","};END{print "]}"}'
+UserParameter=lvm.data[*],LVM_SUPPRESS_FD_WARNINGS=1 lvs --no-heading -o lv_dm_path,$2|awk '$1~/$$1/{print $$2}'


### PR DESCRIPTION
Awk is powerful and can be used without sed or any other tool.

* `$1~/^t/` - instead `cut | grep`
* `l=split($2,b,"/");` - instead `sed`

Also remove unwanted spaces and newlines in json. For human readable json just use `some_command | python -m json.tool`